### PR TITLE
Add configuration for the stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,14 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 0
+# Issues with these labels will never be considered stale
+#exemptLabels:
+#  - pinned
+#  - security
+# Label to use when marking an issue as stale
+#staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: false
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
As mentioned in [this commit](https://github.com/dotnet/announcements/commit/08a471804c8319f1ffcd509918866833caaa0558) we'd like to close issues after 30 days. @gep13 suggested to automate this using the [stale bot](https://probot.github.io/apps/stale/).

@Petermarcu @richlander  @jongalloway: any concerns?